### PR TITLE
root.go: fix max random index for slice "sites"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,10 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("while reading URLs from %q: %v", urls, err)
 		}
+		sites_len := len(sites)
+		if sites_len == 0 {
+			return fmt.Errorf("no URLs in %q", urls)
+		}
 
 		client := &http.Client{Timeout: timeout}
 		sema := make(chan struct{}, goroutines)
@@ -53,7 +57,7 @@ var rootCmd = &cobra.Command{
 		r := rand.New(seed)
 		for {
 			sema <- struct{}{}
-			i := r.Intn(len(sites) - 1)
+			i := r.Intn(sites_len)
 			s := sites[i]
 
 			go func(site string) {


### PR DESCRIPTION
the last "sites" element is always ignoring. according to doc
https://golang.org/pkg/math/rand/#Rand.Intn, the "Intn" argument
is a "... number in [0,n).", so no need to substract the 1 from
"sites" length.
moreover, in case of empty urls list the "Intn" argument will be
negative integer (-1), and this in turn causes a panic.